### PR TITLE
NodeDataset: New DataStructure

### DIFF
--- a/nodestudio/api/websocket.py
+++ b/nodestudio/api/websocket.py
@@ -29,7 +29,7 @@ class WebsocketManager:
 
     async def emit(self, eventName, message):
         await self.sio.emit(eventName, message)
-        await self.sio.emit(eventName, message)
+        await self.sio.sleep(0)
 
 manager = WebsocketManager()
 

--- a/nodestudio/core/dataset.py
+++ b/nodestudio/core/dataset.py
@@ -1,0 +1,48 @@
+import numpy as np
+from dosma import MedicalVolume
+from core.metadata import NodeMetadata
+
+class NodeDataset():
+    
+    def __init__(self, data, metadata: NodeMetadata, dims = [], tag = ''): 
+        self.data = data  # numpy array data
+        self.metadata = metadata # NodeMetadata
+        self.dims = dims # array of the names of data dimensions
+        self.tag = tag # optional - tag info
+
+    def __repr__(self):
+        return f'NodeDataset: {self.shape}, {self.dims}'
+
+    def __getitem__(self, key):
+        return self.data[key]
+
+    def __setitem__(self, key, newvalue):
+        self.data[key] = newvalue
+
+    def to_medicalvolume(self):
+        if self.ndim == 3:
+            if self.metadata.type == 'dicom':
+                headers = self.metadata.headers
+            else:
+                headers = None
+            data = np.moveaxis(self.data, 0, 2)
+            mv = MedicalVolume(data, np.eye(4), headers=headers)
+            return mv
+        
+    def to_numpy(self):
+        return self.data
+
+    @property
+    def shape(self):
+        """The shape of the underlying ndarray."""
+        return self.data.shape
+
+    @property
+    def ndim(self):
+        """int: The number of dimensions of the underlying ndarray."""
+        return self.data.ndim
+
+    @property
+    def dtype(self):
+        """The ``dtype`` of the ndarray. Same as ``self.volume.dtype``."""
+        return self.data.dtype

--- a/nodestudio/core/docs.md
+++ b/nodestudio/core/docs.md
@@ -1,0 +1,15 @@
+
+file types:
+dicom: dcm, ima, dicom
+raw: dat
+
+pixeldata: 
+shape
+ndim
+dtype
+
+metadata: (import key/values)
+pixel_spacing
+scanner_origin
+affine
+

--- a/nodestudio/core/io.py
+++ b/nodestudio/core/io.py
@@ -1,0 +1,111 @@
+
+from email import header
+import os
+import glob
+import pydicom
+import numpy as np
+import mapvbvd
+from requests import head
+
+from core.dataset import NodeDataset
+from core.metadata import NodeMetadata
+
+def read_dicom(filepath, group_by=None, sort_by=None):
+    ''' Reads dicom files from a folder or single file. Groups data if group_by is set to tag in dicom header'''
+
+    # Get filenames and sort alphabetically
+    if os.path.isdir(filepath):
+        paths = glob.glob(filepath + '*.dcm')
+    elif os.path.isfile(filepath):
+        paths = [filepath]
+    else:
+        raise IOError(f"No directory or file found: {filepath}")
+    paths = sorted(paths)
+
+    # Read dicom files
+    headers = {}
+    for idx, path in enumerate(paths):
+        dicom = pydicom.dcmread(path, force=True)
+
+        # Group dicoms by group_by tag
+        if group_by:
+            group_key = dicom.EchoNumbers
+        else:
+            group_key = 0
+
+        if group_key in headers:
+            headers[group_key].append(dicom)
+        else:
+            headers[group_key] = [dicom]
+
+    # TODO: sort_by tag after group_by
+
+    # For each datagroup item - Create a dataset
+    datagroup = []
+    for key in headers.keys():
+        depth = len(headers[key])
+        height = headers[key][0].pixel_array.shape[0]
+        width = headers[key][0].pixel_array.shape[1]
+
+        # Create data array from dicoms
+        for idx, header in enumerate(headers[key]):
+            data = np.zeros((depth, height, width), dtype='uint16')
+            data[idx,:,:] = header.pixel_array
+
+        # Create metadata and datasets
+        metadata = NodeMetadata(headers[group_key], 'dicom')
+        dataset = NodeDataset(data, metadata, ['Sli', 'Lin', 'Col'])
+        datagroup.append(dataset)
+
+    if len(datagroup) == 1:
+        return datagroup[0]
+    else:
+        return datagroup
+
+    '''
+    dataset = pydicom.dcmread(paths[0])
+    depth = len(paths)
+    height = dataset.pixel_array.shape[0]
+    width = dataset.pixel_array.shape[1]
+
+    headers = []
+    data = np.zeros((depth, height, width), dtype='uint16')
+    for idx, path in enumerate(paths):
+        dataset = pydicom.dcmread(path, force=True)
+        data[idx,:,:] = dataset.pixel_array
+        headers.append(dataset)
+
+    metadata = NodeMetadata(headers, 'dicom')
+    dataset = NodeDataset(data, metadata, ['Sli', 'Lin', 'Col'])
+    return dataset
+    '''
+
+def read_rawdata(filepath, datatype='image'):
+    ''' Reads rawdata files and returns NodeDataset '''
+
+    twixObj = mapvbvd.mapVBVD(filepath)
+    sqzDims = twixObj.image.sqzDims    
+    twixObj.image.squeeze = True
+
+    data = twixObj.image['']
+    # Move Lin be first index
+    linIndex = sqzDims.index('Lin')
+    data = np.moveaxis(data, linIndex, 0)
+    sqzDims.insert(0, sqzDims.pop(linIndex))
+
+    if datatype == 'image':
+        data = np.fft.fftshift(np.fft.ifft2(np.fft.fftshift(data, axes=(0, 1)), axes=(0, 1)), axes=(0, 1))
+    else: # datatype is kspace
+        pass
+
+    if 'Sli' in sqzDims:
+        sliceIndex = sqzDims.index('Sli')
+        data = np.moveaxis(data, sliceIndex, 0)
+        sqzDims.insert(0, sqzDims.pop(sliceIndex))
+    else:
+        # Make 2d dataset into 3d dataset with one slice
+        data = np.expand_dims(data, axis=0)
+
+    metadata = NodeMetadata(twixObj.hdr, 'rawdata')
+    dataset = NodeDataset(data, metadata, sqzDims)
+    return dataset

--- a/nodestudio/core/metadata.py
+++ b/nodestudio/core/metadata.py
@@ -1,0 +1,52 @@
+
+class NodeMetadata:
+
+    def __init__(self, headers, type):
+        self.type = type
+        self.headers = headers
+        # TODO: deal with metadata case for phantom data without headers 
+
+    def __repr__(self):
+        return f'''NodeMetadata: 
+    PixelSpacing:{self.pixel_spacing}  
+    TE:{self.echo_time}  
+    TR:{self.repetition_time}  
+    FlipAngle:{self.flip_angle}'''
+
+    @property
+    def pixel_spacing(self):
+        """The ``dtype`` of the ndarray. Same as ``self.volume.dtype``."""
+        if self.type == 'dicom':
+            dxy = self.headers[0].PixelSpacing
+            dz = self.headers[0].SliceThickness
+            return [float(dz), float(dxy[0]), float(dxy[1])]
+        elif self.type == 'rawdata':
+            ny = self.headers.Config.RawLin
+            nx = self.headers.Config.RawCol
+            dy = self.headers.MeasYaps[('sSliceArray', 'asSlice', '0', 'dPhaseFOV')] / nx
+            dx = self.headers.MeasYaps[('sSliceArray', 'asSlice', '0', 'dReadoutFOV')] / ny
+            dz = self.headers.MeasYaps[('sSliceArray', 'asSlice', '0', 'dThickness')]
+            return [dz, dy, dx]
+
+    @property
+    def echo_time(self):
+        ''' TE in ms '''
+        if self.type == 'dicom':
+            return self.headers[0].EchoTime
+        elif self.type == 'rawdata':
+            return self.headers.MeasYaps[('alTE', '0')] / 1000.0
+
+    @property
+    def repetition_time(self):
+        ''' TE in ms '''
+        if self.type == 'dicom':
+            return self.headers[0].RepetitionTime
+        elif self.type == 'rawdata':
+            return self.headers.MeasYaps[('alTR', '0')] / 1000.0
+
+    @property
+    def flip_angle(self):
+        if self.type == 'dicom':
+            return self.headers[0].FlipAngle
+        if self.type == 'rawdata':
+            return self.headers.MeasYaps[('adFlipAngleDegree', '0')]


### PR DESCRIPTION
Resolves #121 

Create a new datastructure to pass between nodes as input / output data

NodeDataset 
- will support ndim data
- can be accesed similar to numpy array 
- has metadata with access to headers and header properties

IO
- read_dicom: reads dicom with support for NodeDataset
- read_rawdata: reads raw data with support for NodeDataset